### PR TITLE
Fix out of range and header pinning issues

### DIFF
--- a/Runtime/Core/RSRBase.Sections.cs
+++ b/Runtime/Core/RSRBase.Sections.cs
@@ -42,30 +42,40 @@ namespace RecyclableScrollRect
         {
             if (!headerPin.IsPinned)
                 return;
-            
-            var currentHeaderSection = _itemData[headerPin.index].sectionIndex;
-            if (_visibleItems.TryGetValue(headerPin.index, out var headerItem))
+
+            var headerIndex = headerPin.index;
+            headerPin.index = -1;
+
+            if (headerIndex < _itemData.Count && _visibleItems.TryGetValue(headerIndex, out var headerItem))
             {
+                var currentHeaderSection = _itemData[headerIndex].sectionIndex;
                 headerItem.transform.SetParent(content, true);
-                headerItem.transform.SetSiblingIndex(headerPin.index);
-                RestoreItemPosition(headerPin.index);
+                headerItem.transform.SetSiblingIndex(headerIndex);
+                RestoreItemPosition(headerIndex);
                 // hide the header as if its no longer in the viewport and the section has changed
-                if (headerPin.index < _minExtraVisibleRowColumnInViewPort && _currentSection != currentHeaderSection)
+                if (headerIndex < _minExtraVisibleRowColumnInViewPort && _currentSection != currentHeaderSection)
                 {
-                    HideItemAtIndex(headerPin.index);
+                    HideItemAtIndex(headerIndex);
                 }
-                headerPin.index = -1;
+            }
+
+            if (_headersParent != null)
+            {
                 SetHeadersParentSize();
             }
         }
 
         private void PinHeaders()
         {
-            _currentSection = _itemData[GetEffectiveMinVisibleIndex()].sectionIndex;
-            
             if (_sectionsSource == null)
                 return;
-            
+
+            var minVisibleIndex = GetEffectiveMinVisibleIndex();
+            if (minVisibleIndex < 0 || minVisibleIndex >= _itemData.Count)
+                return;
+
+            _currentSection = _itemData[minVisibleIndex].sectionIndex;
+
             if (_sectionsSource.ScrollRectHasHeader && _sectionsSource.ScrollRectHeaderIsPinned && !_rsrHeaderPin.IsPinned)
                 PinHeader(_rsrHeaderPin, true);
             
@@ -93,11 +103,10 @@ namespace RecyclableScrollRect
 
         private void PinHeader(PinnedHeaderState headerPin, bool isRSRHeader)
         {
-            var currentHeaderIndex = GetHeaderIndexFromSection(_currentSection);
-            if (headerPin.index == currentHeaderIndex)
+            var headerIndex = isRSRHeader ? 0 : GetHeaderIndexFromSection(_currentSection);
+            if (headerIndex < 0 || headerPin.index == headerIndex)
                 return;
 
-            var headerIndex = isRSRHeader ? 0 : GetHeaderIndexFromSection(_currentSection);
             if (!ShouldBePinned(headerIndex, isRSRHeader))
                 return;
 

--- a/Runtime/Core/RSRGrid.cs
+++ b/Runtime/Core/RSRGrid.cs
@@ -340,6 +340,16 @@ namespace RecyclableScrollRect
             base.RemoveExtraItems(itemDiff);
 
             var lastItemFlatIndex = LastLineStartIndex;
+            if (lastItemFlatIndex < _minVisibleRowColumnInViewPort)
+            {
+                _minVisibleRowColumnInViewPort = lastItemFlatIndex;
+            }
+
+            if (lastItemFlatIndex < _minExtraVisibleRowColumnInViewPort)
+            {
+                _minExtraVisibleRowColumnInViewPort = lastItemFlatIndex;
+            }
+
             if (lastItemFlatIndex < _maxVisibleRowColumnInViewPort)
             {
                 _maxVisibleRowColumnInViewPort = lastItemFlatIndex;


### PR DESCRIPTION
Fixes a few bugs found in the header pinning and grid recycling code.

### `ArgumentOutOfRangeException` in `PinHeaders`
`PinHeaders` read `_itemData[GetEffectiveMinVisibleIndex()]` before checking anything, so calling `ReloadData` with an empty data source threw on the very first index. The null check on `_sectionsSource` now runs first and the resolved index is validated against `_itemData` before it is used.

### Pinned header state was never cleared when the header was not visible
`UnpinHeader` only reset `index` to -1 inside the `_visibleItems` lookup, so a pinned header that had already been recycled stayed marked as pinned with a stale index. That index was later used to read `_itemPositions`, which goes out of range once the item count shrinks. The state is now cleared unconditionally and the headers parent size is refreshed in both cases.

### Scroll rect header could not be pinned in sections without a header
`PinHeader` compared `headerPin.index` against `GetHeaderIndexFromSection(_currentSection)` even for the scroll rect header, whose index is always 0. In a section without a header that call returns -1, which matches the unpinned state, so the function returned early and the scroll rect header never pinned. The comparison now uses the index that is actually about to be pinned, and a negative index is rejected.

### Stale grid indices after the item count shrinks
`RSRGrid.RemoveExtraItems` clamped only the max visible indices. After reloading with fewer items, `_minVisibleRowColumnInViewPort` and `_minExtraVisibleRowColumnInViewPort` could still point past the last line and were then used to index `_itemPositions`. Both are now clamped to the last line as well.
